### PR TITLE
re-implement it.Count

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,17 @@ Experimental: `Chunk` on iterators
 it.Chunk(it.Range(5), 2)
 // it.SliceValues([][]int{{0, 1}, {2, 3}, {4}})
 ```
+
+### Count
+
+```go
+hi.Count([]int{1, 2, 3, 4, 5}, 3)
+// 1
+```
+
+Experimental: `Count` on iterators
+
+```go
+it.Count(it.Range(5), 3)
+// 1
+```

--- a/it/example_test.go
+++ b/it/example_test.go
@@ -138,3 +138,9 @@ func ExampleChunk() {
 	// [2 3]
 	// [4]
 }
+
+func ExampleCount() {
+	fmt.Println(it.Count(it.Range(5), 3))
+	// Output:
+	// 1
+}

--- a/it/itertools.go
+++ b/it/itertools.go
@@ -6,23 +6,6 @@ import (
 	"iter"
 )
 
-type Countable interface {
-	~int | ~int8 | ~int16 | ~int32 | ~int64 |
-		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr |
-		~float32 | ~float64
-}
-
-// Count makes an iterator that returns evenly spaced values starting with number start.
-func Count[T Countable](start, step T) func(func(T) bool) {
-	return func(yield func(T) bool) {
-		for i := start; ; i += step {
-			if !yield(i) {
-				break
-			}
-		}
-	}
-}
-
 // Cycle makes an iterator returning elements from the iterable and saving a copy of each.
 func Cycle[T any](seq iter.Seq[T]) func(func(T) bool) {
 	return func(yield func(T) bool) {

--- a/it/itertools_test.go
+++ b/it/itertools_test.go
@@ -8,20 +8,6 @@ import (
 	"testing"
 )
 
-func TestCount(t *testing.T) {
-	got := make([]int, 0, 5)
-	for v := range Count(0, 2) {
-		got = append(got, v)
-		if len(got) >= 5 {
-			break
-		}
-	}
-	want := []int{0, 2, 4, 6, 8}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
-	}
-}
-
 func TestCycle(t *testing.T) {
 	got := make([]int, 0, 10)
 	seq := SliceValues([]int{1, 2, 3, 4})

--- a/it/tools.go
+++ b/it/tools.go
@@ -199,3 +199,14 @@ func Chunk[T any](seq iter.Seq[T], size int) func(func([]T) bool) {
 		}
 	}
 }
+
+// Count counts the number of elements in the collection that compare equal to value.
+func Count[T comparable](seq iter.Seq[T], value T) int {
+	var count int
+	for v := range seq {
+		if v == value {
+			count++
+		}
+	}
+	return count
+}

--- a/slice_example_test.go
+++ b/slice_example_test.go
@@ -91,6 +91,13 @@ func ExampleChunk() {
 	// [5]
 }
 
+func ExampleCount() {
+	input := []int{1, 2, 3, 4, 5}
+	fmt.Println(hi.Count(input, 3))
+	// Output:
+	// 1
+}
+
 func ExampleAny() {
 	input := []int{1, 2, 3, 4, 5}
 	fmt.Println(hi.Any(input, 5))


### PR DESCRIPTION
`hi.Count` and `it.Count`, despite having the same name, have entirely different functionalities.
This fact is likely to confuse users. 
We will re-implement `it.Count` to function similarly to `hi.Count`.