### PR TITLE
drop Go 1.25 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,8 @@ jobs:
       matrix:
         go:
           - "stable"
-          - "1.23"
+          - "1.27-rc2"
+          - "1.26"
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         go:
           - "stable"
-          - "1.27-rc2"
+          - "1.27.0-rc.2"
           - "1.26"
     steps:
       - uses: actions/checkout@v7

--- a/func_example_test.go
+++ b/func_example_test.go
@@ -10,7 +10,7 @@ func ExampleNegate() {
 	f := func(v int) bool { return v > 3 }
 	g := hi.Negate(f)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		fmt.Printf("%d: %t, %t\n", i, f(i), g(i))
 	}
 
@@ -26,7 +26,7 @@ func ExampleNegate2() {
 	f := func(a, b int) bool { return a > b }
 	g := hi.Negate2(f)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		fmt.Printf("%d: %t, %t\n", i, f(i, 3), g(i, 3))
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/shogo82148/hi
 
-go 1.23.0
+go 1.26.0

--- a/it/tools.go
+++ b/it/tools.go
@@ -82,7 +82,7 @@ func ChanValues[T any](x <-chan T) func(func(T) bool) {
 // Range returns an iterator for the range.
 func Range(n int) func(func(int) bool) {
 	return func(yield func(int) bool) {
-		for i := 0; i < n; i++ {
+		for i := range n {
 			if !yield(i) {
 				break
 			}

--- a/it/tools_test.go
+++ b/it/tools_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAppend(t *testing.T) {
 	seq := func(yield func(int) bool) {
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			if !yield(i) {
 				break
 			}
@@ -123,7 +123,7 @@ func TestMax_Nan(t *testing.T) {
 func TestSample(t *testing.T) {
 	seq := SliceValues([]int{1, 2, 3, 4, 5})
 	count := make([]int, 6)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		ret := Sample(seq)
 		if !ret.Valid() {
 			t.Errorf("Sample() = %t, want %t", ret.Valid(), true)
@@ -143,7 +143,7 @@ func TestSample2(t *testing.T) {
 	slice := []string{"zero", "one", "two", "three", "four"}
 	seq := SliceIter(slice)
 	count := make([]int, 5)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		ret := Sample2(seq)
 		if !ret.Valid() {
 			t.Errorf("Sample2() = %t, want %t", ret.Valid(), true)
@@ -158,14 +158,14 @@ func TestSample2(t *testing.T) {
 		count[got.V1]++
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		t.Logf("count[%d] = %d", i, count[i])
 	}
 }
 
 func TestSampleN(t *testing.T) {
 	seq := SliceValues([]int{1, 2, 3, 4, 5})
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		ret := SampleN(seq, 3)
 		if len(ret) != 3 {
 			t.Errorf("SampleN() = %d, want 3", len(ret))
@@ -181,7 +181,7 @@ func TestSampleN(t *testing.T) {
 func TestSampleN2(t *testing.T) {
 	slice := []string{"zero", "one", "two", "three", "four"}
 	seq := SliceIter(slice)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		ret := SampleN2(seq, 3)
 		if len(ret) != 3 {
 			t.Errorf("SampleN2() = %d, want 3", len(ret))

--- a/list/iter_test.go
+++ b/list/iter_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestForward(t *testing.T) {
 	l := New[string]()
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		l.PushBack(fmt.Sprintf("%d", i))
 	}
 
@@ -24,7 +24,7 @@ func TestForward(t *testing.T) {
 
 func TestBackward(t *testing.T) {
 	l := New[string]()
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		l.PushBack(fmt.Sprintf("%d", i))
 	}
 

--- a/optional/example_test.go
+++ b/optional/example_test.go
@@ -23,7 +23,7 @@ func ExampleUnzip2() {
 	// one
 }
 
-func ExampleFilter() {
+func ExampleOptional_Filter() {
 	filter := func(v int) bool { return v > 20 }
 
 	v := optional.New(10).Filter(filter)
@@ -37,7 +37,7 @@ func ExampleFilter() {
 	// true
 }
 
-func ExampleFilterFalse() {
+func ExampleOptional_FilterFalse() {
 	filter := func(v int) bool { return v > 20 }
 
 	v := optional.New(10).FilterFalse(filter)

--- a/pointer.go
+++ b/pointer.go
@@ -1,6 +1,8 @@
 package hi
 
 // Ptr returns a pointer to v.
+//
+//go:fix inline
 func Ptr[T any](v T) *T {
-	return &v
+	return new(v)
 }

--- a/pointer_example_test.go
+++ b/pointer_example_test.go
@@ -2,10 +2,12 @@ package hi_test
 
 import (
 	"fmt"
+
+	"github.com/shogo82148/hi"
 )
 
 func ExamplePtr() {
-	p := new("hello")
+	p := hi.Ptr("hello")
 	fmt.Println(*p)
 
 	// Output:

--- a/pointer_example_test.go
+++ b/pointer_example_test.go
@@ -2,12 +2,10 @@ package hi_test
 
 import (
 	"fmt"
-
-	"github.com/shogo82148/hi"
 )
 
 func ExamplePtr() {
-	p := hi.Ptr("hello")
+	p := new("hello")
 	fmt.Println(*p)
 
 	// Output:

--- a/result/example_test.go
+++ b/result/example_test.go
@@ -17,7 +17,7 @@ func ExampleUnzip2() {
 	// one
 }
 
-func ExampleFilter() {
+func ExampleResult_Filter() {
 	filter := func(v int) bool { return v > 20 }
 
 	v := result.OK(10).Filter(filter)
@@ -31,7 +31,7 @@ func ExampleFilter() {
 	// <nil>
 }
 
-func ExampleFilterFalse() {
+func ExampleResult_FilterFalse() {
 	filter := func(v int) bool { return v > 20 }
 
 	v := result.OK(10).FilterFalse(filter)

--- a/slice.go
+++ b/slice.go
@@ -68,10 +68,7 @@ func Chunk[S ~[]T, T any](a S, size int) []S {
 	}
 	ret := make([]S, 0, (len(a)+size-1)/size)
 	for i := 0; i < len(a); i += size {
-		end := i + size
-		if end > len(a) {
-			end = len(a)
-		}
+		end := min(i+size, len(a))
 		ret = append(ret, a[i:end])
 	}
 	return ret
@@ -132,7 +129,7 @@ func Chain[S ~[]T, T any](a ...S) []T {
 func Compress[S ~[]T, T any](a S, selectors []bool) S {
 	l := min(len(a), len(selectors))
 	ret := make(S, 0, l)
-	for i := 0; i < l; i++ {
+	for i := range l {
 		if selectors[i] {
 			ret = append(ret, a[i])
 		}
@@ -208,12 +205,7 @@ func CountBy[T any](a []T, counter func(int, T) bool) int {
 
 // Any returns whether a has value at least one.
 func Any[T comparable](a []T, value T) bool {
-	for _, v := range a {
-		if v == value {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(a, value)
 }
 
 // AnyBy returns whether a has an element for that f returns true.

--- a/slice_test.go
+++ b/slice_test.go
@@ -67,7 +67,7 @@ func TestMax_Nan(t *testing.T) {
 func TestSample(t *testing.T) {
 	input := []int{1, 2, 3, 4, 5}
 	count := make([]int, 6)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		ret := Sample(input)
 		if !ret.Valid() {
 			t.Errorf("Sample(%v) = %t, want %t", input, ret.Valid(), true)
@@ -86,7 +86,7 @@ func TestSample(t *testing.T) {
 func TestSampleN(t *testing.T) {
 	input := []int{1, 2, 3, 4, 5}
 	count := make(map[tuple.Tuple3[int, int, int]]int)
-	for i := 0; i < 10000; i++ {
+	for range 10000 {
 		ret := SampleN(input, 3)
 		if len(ret) != 3 {
 			t.Errorf("SampleN(%v, 3) = %d, want 3", input, len(ret))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the module’s declared Go version to **1.26**.

* **Tests**
  * Updated CI to run the test suite against **Go 1.26** and **Go 1.27.0-rc.2**.
  * Removed the previous **Go 1.23** entry from the CI test matrix.

* **Documentation**
  * Renamed Go example functions to use clearer, package-scoped names, and refreshed the `ExamplePtr` snippet for consistency.

* **Bug Fixes**
  * Improved pointer creation and refined slice-related logic (including `Chunk`/`Any`) to use safer, more direct implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->