### PR TITLE
Introduce go1.27 generics methods

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -317,7 +317,7 @@ func AllBy[T any](l *List[T], f func(int, T) bool) bool {
 	return true
 }
 
-// Map
+// Map returns a list of the results of applying f to each element of l.
 func Map[T, U any](l *List[T], f func(int, T) U) *List[U] {
 	var ret List[U]
 	for i, e := 0, l.Front(); e != nil; i, e = i+1, e.Next() {

--- a/list/list_go1.27.go
+++ b/list/list_go1.27.go
@@ -35,6 +35,26 @@ func (l *List[T]) CountBy(f func(index int, value T) bool) int {
 	return count
 }
 
+// AnyBy returns whether l has an element for that f returns true.
+func (l *List[T]) AnyBy(f func(index int, value T) bool) bool {
+	for i, e := 0, l.Front(); e != nil; i, e = i+1, e.Next() {
+		if f(i, e.Value) {
+			return true
+		}
+	}
+	return false
+}
+
+// AllBy returns whether f returns true for all elements in l.
+func (l *List[T]) AllBy(f func(int, T) bool) bool {
+	for i, e := 0, l.Front(); e != nil; i, e = i+1, e.Next() {
+		if !f(i, e.Value) {
+			return false
+		}
+	}
+	return true
+}
+
 // Map returns a list of the results of applying f to each element of l.
 func (l *List[T]) Map[U any](f func(index int, value T) U) *List[U] {
 	var ret List[U]

--- a/list/list_go1.27.go
+++ b/list/list_go1.27.go
@@ -64,3 +64,11 @@ func (l *List[T]) Map[U any](f func(index int, value T) U) *List[U] {
 	}
 	return &ret
 }
+
+// Reduce reduces l to a single value which is the accumulated result of running each element in l through the reducer function.
+func (l *List[T]) Reduce[U any](f func(i int, acc U, item T) U, init U) U {
+	for i, e := 0, l.Front(); e != nil; i, e = i+1, e.Next() {
+		init = f(i, init, e.Value)
+	}
+	return init
+}

--- a/list/list_go1.27.go
+++ b/list/list_go1.27.go
@@ -1,0 +1,24 @@
+//go:build go1.27
+
+package list
+
+// Filter iterates over elements of collection, returning a list of all elements predicate returns true for.
+func (l *List[T]) Filter(f func(index int, value T) bool) *List[T] {
+	var ret List[T]
+	for i, e := 0, l.Front(); e != nil; i, e = i+1, e.Next() {
+		if f(i, e.Value) {
+			ret.PushBack(e.Value)
+		}
+	}
+	return &ret
+}
+
+// Map returns a list of the results of applying f to each element of l.
+func (l *List[T]) Map[U any](f func(index int, value T) U) *List[U] {
+	var ret List[U]
+	for i, e := 0, l.Front(); e != nil; i, e = i+1, e.Next() {
+		v := f(i, e.Value)
+		ret.PushBack(v)
+	}
+	return &ret
+}

--- a/list/list_go1.27.go
+++ b/list/list_go1.27.go
@@ -24,6 +24,17 @@ func (l *List[T]) FilterFalse(f func(index int, value T) bool) *List[T] {
 	return &ret
 }
 
+// CountBy counts the number of elements that counter returns true.
+func (l *List[T]) CountBy(f func(index int, value T) bool) int {
+	var count int
+	for i, e := 0, l.Front(); e != nil; i, e = i+1, e.Next() {
+		if f(i, e.Value) {
+			count++
+		}
+	}
+	return count
+}
+
 // Map returns a list of the results of applying f to each element of l.
 func (l *List[T]) Map[U any](f func(index int, value T) U) *List[U] {
 	var ret List[U]

--- a/list/list_go1.27.go
+++ b/list/list_go1.27.go
@@ -2,7 +2,7 @@
 
 package list
 
-// Filter iterates over elements of collection, returning a list of all elements predicate returns true for.
+// Filter returns the elements of l for which f returns true.
 func (l *List[T]) Filter(f func(index int, value T) bool) *List[T] {
 	var ret List[T]
 	for i, e := 0, l.Front(); e != nil; i, e = i+1, e.Next() {
@@ -13,7 +13,7 @@ func (l *List[T]) Filter(f func(index int, value T) bool) *List[T] {
 	return &ret
 }
 
-// FilterFalse iterates over elements of collection, returning a list of all elements predicate returns false for.
+// FilterFalse returns the elements of l for which f returns false.
 func (l *List[T]) FilterFalse(f func(index int, value T) bool) *List[T] {
 	var ret List[T]
 	for i, e := 0, l.Front(); e != nil; i, e = i+1, e.Next() {
@@ -24,7 +24,7 @@ func (l *List[T]) FilterFalse(f func(index int, value T) bool) *List[T] {
 	return &ret
 }
 
-// CountBy counts the number of elements that counter returns true.
+// CountBy returns the number of elements of l for which f returns true.
 func (l *List[T]) CountBy(f func(index int, value T) bool) int {
 	var count int
 	for i, e := 0, l.Front(); e != nil; i, e = i+1, e.Next() {
@@ -35,7 +35,7 @@ func (l *List[T]) CountBy(f func(index int, value T) bool) int {
 	return count
 }
 
-// AnyBy returns whether l has an element for that f returns true.
+// AnyBy reports whether any element of l makes f return true.
 func (l *List[T]) AnyBy(f func(index int, value T) bool) bool {
 	for i, e := 0, l.Front(); e != nil; i, e = i+1, e.Next() {
 		if f(i, e.Value) {
@@ -45,7 +45,7 @@ func (l *List[T]) AnyBy(f func(index int, value T) bool) bool {
 	return false
 }
 
-// AllBy returns whether f returns true for all elements in l.
+// AllBy reports whether all elements of l make f return true.
 func (l *List[T]) AllBy(f func(int, T) bool) bool {
 	for i, e := 0, l.Front(); e != nil; i, e = i+1, e.Next() {
 		if !f(i, e.Value) {

--- a/list/list_go1.27.go
+++ b/list/list_go1.27.go
@@ -13,6 +13,17 @@ func (l *List[T]) Filter(f func(index int, value T) bool) *List[T] {
 	return &ret
 }
 
+// FilterFalse iterates over elements of collection, returning a list of all elements predicate returns false for.
+func (l *List[T]) FilterFalse(f func(index int, value T) bool) *List[T] {
+	var ret List[T]
+	for i, e := 0, l.Front(); e != nil; i, e = i+1, e.Next() {
+		if !f(i, e.Value) {
+			ret.PushBack(e.Value)
+		}
+	}
+	return &ret
+}
+
 // Map returns a list of the results of applying f to each element of l.
 func (l *List[T]) Map[U any](f func(index int, value T) U) *List[U] {
 	var ret List[U]

--- a/list/list_go1.27_test.go
+++ b/list/list_go1.27_test.go
@@ -48,6 +48,21 @@ func TestList_FilterFalse(t *testing.T) {
 	}
 }
 
+func TestList_CountBy(t *testing.T) {
+	l := New[int]()
+	for i := range 5 {
+		l.PushBack(i)
+	}
+
+	count := l.CountBy(func(index int, value int) bool {
+		return value%2 == 0
+	})
+
+	if count != 3 {
+		t.Errorf("got %d, want %d", count, 3)
+	}
+}
+
 func TestList_Map(t *testing.T) {
 	l := New[int]()
 	for i := range 5 {

--- a/list/list_go1.27_test.go
+++ b/list/list_go1.27_test.go
@@ -1,0 +1,49 @@
+//go:build go1.27
+
+package list
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+)
+
+func TestList_Filter(t *testing.T) {
+	l := New[int]()
+	for i := range 5 {
+		l.PushBack(i)
+	}
+
+	filtered := l.Filter(func(index int, value int) bool {
+		return value%2 == 0
+	})
+
+	got := make([]int, 0, filtered.Len())
+	for _, v := range filtered.Forward() {
+		got = append(got, v)
+	}
+	want := []int{0, 2, 4}
+	if !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestList_Map(t *testing.T) {
+	l := New[int]()
+	for i := range 5 {
+		l.PushBack(i)
+	}
+
+	mapped := l.Map(func(index int, value int) string {
+		return fmt.Sprintf("%d:%d", index, value)
+	})
+
+	got := make([]string, 0, mapped.Len())
+	for _, v := range mapped.Forward() {
+		got = append(got, v)
+	}
+	want := []string{"0:0", "1:1", "2:2", "3:3", "4:4"}
+	if !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/list/list_go1.27_test.go
+++ b/list/list_go1.27_test.go
@@ -132,3 +132,18 @@ func TestList_Map(t *testing.T) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 }
+
+func TestList_Reduce(t *testing.T) {
+	l := New[int]()
+	for i := range 5 {
+		l.PushBack(i)
+	}
+
+	sum := l.Reduce(func(index int, acc int, value int) int {
+		return acc + value
+	}, 0)
+
+	if sum != 10 {
+		t.Errorf("got %d, want %d", sum, 10)
+	}
+}

--- a/list/list_go1.27_test.go
+++ b/list/list_go1.27_test.go
@@ -28,6 +28,26 @@ func TestList_Filter(t *testing.T) {
 	}
 }
 
+func TestList_FilterFalse(t *testing.T) {
+	l := New[int]()
+	for i := range 5 {
+		l.PushBack(i)
+	}
+
+	filtered := l.FilterFalse(func(index int, value int) bool {
+		return value%2 == 0
+	})
+
+	got := make([]int, 0, filtered.Len())
+	for _, v := range filtered.Forward() {
+		got = append(got, v)
+	}
+	want := []int{1, 3}
+	if !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
 func TestList_Map(t *testing.T) {
 	l := New[int]()
 	for i := range 5 {

--- a/list/list_go1.27_test.go
+++ b/list/list_go1.27_test.go
@@ -63,6 +63,56 @@ func TestList_CountBy(t *testing.T) {
 	}
 }
 
+func TestList_AnyBy(t *testing.T) {
+	l := New[int]()
+	for i := range 5 {
+		l.PushBack(i)
+	}
+
+	if !l.AnyBy(func(index int, value int) bool {
+		return value%2 == 0
+	}) {
+		t.Errorf("got false, want true")
+	}
+
+	if l.AnyBy(func(index int, value int) bool {
+		return value > 5
+	}) {
+		t.Errorf("got true, want false")
+	}
+
+	if !l.AllBy(func(index int, value int) bool {
+		return value < 5
+	}) {
+		t.Errorf("got false, want true")
+	}
+
+	if l.AllBy(func(index int, value int) bool {
+		return value%2 == 0
+	}) {
+		t.Errorf("got true, want false")
+	}
+}
+
+func TestList_AllBy(t *testing.T) {
+	l := New[int]()
+	for i := range 5 {
+		l.PushBack(i)
+	}
+
+	if !l.AllBy(func(index int, value int) bool {
+		return value < 5
+	}) {
+		t.Errorf("got false, want true")
+	}
+
+	if l.AllBy(func(index int, value int) bool {
+		return value%2 == 0
+	}) {
+		t.Errorf("got true, want false")
+	}
+}
+
 func TestList_Map(t *testing.T) {
 	l := New[int]()
 	for i := range 5 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Go 1.27–only generic `List` operations: `Filter`, `FilterFalse`, `CountBy`, `AnyBy`, `AllBy`, `Map`, and `Reduce`, including order-preserving transformations and accumulation.
* **Documentation**
  * Clarified the behavior description for the generic mapping operation.
* **Tests**
  * Added unit tests covering filtering, counting, predicate evaluation, mapping, and reducing on generic lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->